### PR TITLE
Add Node Version Checking

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true

--- a/package.json
+++ b/package.json
@@ -23,4 +23,7 @@
     "typescript": "^4.2.4",
     "xmlhttprequest": "^1.8.0"
   }
+  "engines": {
+    "node": ">=0.11"
+  }
 }


### PR DESCRIPTION
Since this project does not work in Node versions 10 or lower:

* Add a Node 11+ engine requirement to package.json: This can head off mysterious test failures due to older versions of Node.

* Add an .npmrc to enavle strict engine checking: This flag will cause node versions less than 11 to throw a version compatibility error at build time.  (Without this, version mismatches would only result in a warning.)